### PR TITLE
Power Cone constraint implementation

### DIFF
--- a/sageopt/coniclifts/cones.py
+++ b/sageopt/coniclifts/cones.py
@@ -37,8 +37,8 @@ class Cone(object):
     """
     Cone types can be '+' for nonnegative orthant, '0' for zero-cone,
     'fr' for the free (unconstrained) cone,  'e' for exponential cone,
-    'de' for dual exponential cone, 'S' for second order cone, and 'P'
-    for positive semidefinite cone.
+    'de' for dual exponential cone, 'S' for second order cone, 'P'
+    for positive semidefinite cone, and 'pow' for power cone.
     """
 
     def __init__(self, cone_type, length, annotations=None):

--- a/sageopt/coniclifts/constraints/set_membership/pow_cone.py
+++ b/sageopt/coniclifts/constraints/set_membership/pow_cone.py
@@ -9,7 +9,7 @@ from sageopt.coniclifts.problems.problem import Problem
 class PowCone(SetMembership):
     """
     A power cone constraint is defined with an n-dimensional vector
-    :math:'\alpha' which is elementwise positive and
+    :math:'\\alpha' which is elementwise positive and
     sums to 1. The cone can be summarized by writing that
     :math:'(w, z) \\in C_{\\mathrm{power}}' if:
 

--- a/sageopt/coniclifts/constraints/set_membership/pow_cone.py
+++ b/sageopt/coniclifts/constraints/set_membership/pow_cone.py
@@ -7,42 +7,92 @@ from sageopt.coniclifts.problems.problem import Problem
 
 
 class PowCone(SetMembership):
+    """
+    A power cone constraint is defined with an n-dimensional vector
+    :math:'\alpha' which is elementwise positive and
+    sums to 1. The cone can be summarized by writing that
+    :math:'(w, z) \\in C_{\\mathrm{power}}' if:
+
+    .. math::
+        \\prod_{i=0}^n w_i^\\alpha_i > \\| z \\|
+
+    where :math:'w' is an n dimensional vector and :math:'z' is a scalar.
+
+    Parameters
+    ----------
+
+    w : Expression
+
+        An (n+1)-dimensional vector subject to this Power Cone constraints.
+        One element of this vector is z which is
+        determined by the elements of
+
+    lamb: ndarray
+        An (n+1)-dimensional array with 1 negative entry and n positive entries
+        whose sum is 0. The n positive entries determine the elements of
+        :math:'\\alpha' while the negative entry of lamb determines the index of
+        z within the w parameter.
+
+
+    Attributes
+    ----------
+    id: int
+        The id of the Power Cone constraint object
+
+    w : Expression
+        The inputted (n+1)-dimensional vector inputted
+        into the Power Cone constructor
+
+    lamb : ndarray
+        The inputted (n+1)-dimensional array inputted into the
+        Power Cone constructor that sums to 0
+
+    w_low : Expression
+        An n-dimensional expression used to describe w in the Power Cone
+
+    z_low : Expression
+        A scalar expression used to describe z in the Power Cone
+
+    alpha : ndarray
+        The n-dimensional vector :math:'\\alpha' that sums to 1
+        that defines the power Cone constraint
+
+    Notes
+    -----
+
+    The constructor can raise a RuntimeError if the constraint is deemed infeasible.
+    """
     _CONSTRAINT_ID_ = 0
 
-    """
-        Creates an instance of a Power Cone whose constraints are described in cone_standards.txt
-        
-         In this constructor, w is an (n+1)-vector and lamb is an (n+1) vector with exactly one negative 
-         component.  lamb in the input corresponds to alpha in the description of a power cone.
-         
-         The negative number in lamb corresponds to the index of w that is z in the description of a power cone.
-    """
     def __init__(self, w, lamb):
+
         self.id = PowCone._CONSTRAINT_ID_
         PowCone._CONSTRAINT_ID_ += 1
 
         # Finds indices of all positive elements of lambs (alpha)
         pos_idxs = lamb > 0
 
-        #Error if lamb and w are not same size
+        # Error if lamb and w are not same size
         if not w.size == lamb.size:
-            raise RuntimeError('Incompatible dimensions for w (' + str(w.size) + ') and alpha (' + str(lamb.size) + ')')
+            msg = 'Incompatible dimensions for w (%s) and alpha (%s)' % (w.size, lamb.size)
+            raise ValueError(msg)
 
         # Error if alpha has no negative number
-        if np.sum(pos_idxs) == np.size(lamb):
-            raise ValueError('No negative number in lamb array')
+        if np.all(pos_idxs):
+            msg = 'No negative number in inputted lamb array'
+            raise ValueError(msg)
 
-        negative = lamb[lamb < 0]
-        posotive = np.sum(lamb[pos_idxs])
-        if np.sum(lamb[pos_idxs]) + lamb[lamb < 0] != 0:
-            raise ValueError('lamb does not have sum of 0')
+        neg_idxs = lamb < 0
+        if np.sum(lamb) != 0:
+            msg = 'lamb does not have sum of 0'
+            raise ValueError(msg)
+
         # Get positive values and normalize
-        alpha_low = lamb[pos_idxs]/np.abs(lamb[lamb < 0])
-
+        alpha_low = lamb[pos_idxs]/np.abs(lamb[neg_idxs])
 
         # Negative number corresponds to z in power cone and rest of numpy array is w
         w_low = w[pos_idxs]
-        z_low = w[lamb < 0]
+        z_low = w[neg_idxs]
 
         if not isinstance(w_low, Expression):
             w_low = Expression(w_low)
@@ -56,16 +106,19 @@ class PowCone(SetMembership):
         self.alpha = alpha_low
         pass
 
-    """
-        Returns a list of all the variables asssociated with this power cone
-    """
     def variables(self):
+        """
+        Return a list of all Variable objects appearing in this Power Cone constraint object
 
+        Returns
+        -------
+        - A list of all the variables involved in the Power Cone constraint of this object
+        """
         var_ids = set()
         var_list = []
 
         # Grab non duplicate elements from w
-        for se in self.w_low.ravel():
+        for se in self.w_low.flat():
             for sv in se.scalar_variables():
                 if id(sv.parent) not in var_ids:
                     var_ids.add(id(sv.parent))
@@ -79,15 +132,21 @@ class PowCone(SetMembership):
 
         return var_list
 
-    """
-        Returns the sparse form representation of the Power Cone problem (Ax = b)
-        
-        The returned elements follow the conic form method in constraint.py. Additionally, the cones with K contains an 
-        annotation that store the alpha parameter of this power cone object.
-    """
     def conic_form(self):
+        """
+        Returns a sparse matrix representation of the Power cone object. It represents of the object as
+        :math:'Ax+b \\in K' where K is a cone object
+
+        Returns
+        -------
+        A_vals - list (of floats)
+        A_rows - numpy 1darray (of integers)
+        A_cols - list (of integers)
+        b - numpy 1darray (of floats)
+        K - list (of coniclifts Cone objects)
+        """
         A_rows, A_cols, A_vals = [], [], []
-        K = [Cone('pow', self.w.size, annotations={'weights': np.array(self.alpha).tolist()})]
+        K = [Cone('pow', self.w.size, annotations={'weights': self.alpha.tolist()})]
         b = np.zeros(shape=(self.w.size,))
 
         # Loop through w and add every variable
@@ -124,6 +183,17 @@ class PowCone(SetMembership):
 
     @staticmethod
     def project(item, alpha):
+        """
+        Calculates the shortest distance (the projection) of a vector to a cone parametrized by :math:'\\alpha'
+        Parameters
+        ----------
+        item - the point we are projecting
+        alpha - the :math:'\\alpha' parameter for the Cone that we are projecting to
+
+        Returns
+        -------
+        The distance of the projection to the Cone
+        """
         from sageopt.coniclifts import MIN as CL_MIN
 
         item = Expression(item).ravel()
@@ -140,10 +210,20 @@ class PowCone(SetMembership):
 
         return prob.value
 
-    """
-    Returns the violation of the current values of this object 
-    """
-    def violation(self, rough = False):
+    def violation(self, rough=False):
+        """
+        Returns the violation of stored w and z to being in the Power cone parametrized by alpha. If rough = True, then
+        measures the violation based off the maximum violation of the condition of the Power Cone. If not, it is based
+        off the projection distance between the point and Cone.
+
+        Parameters
+        ----------
+        rough - whether to use a rough approximation of the violation
+
+        Returns
+        -------
+        The value of the violation of this object's w and z
+        """
         if rough:
             return np.max([np.abs(self.z_low.value) - np.prod(np.power(self.w_low.value, self.alpha)), 0])
         else:

--- a/sageopt/coniclifts/constraints/set_membership/pow_cone.py
+++ b/sageopt/coniclifts/constraints/set_membership/pow_cone.py
@@ -1,6 +1,6 @@
 import numpy as np
 from sageopt.coniclifts.constraints.set_membership.setmem import SetMembership
-from sageopt.coniclifts.base import Expression, ScalarVariable, Variable, ScalarExpression
+from sageopt.coniclifts.base import Expression, ScalarVariable, Variable
 from sageopt.coniclifts.cones import Cone
 from sageopt.coniclifts.operators.norms import vector2norm
 from sageopt.coniclifts.problems.problem import Problem
@@ -78,7 +78,7 @@ class PowCone(SetMembership):
         return var_list
 
     """
-    
+        Returns the sparse form representation of the Power Cone problem (Ax = b)
     """
     def conic_form(self):
         A_rows, A_cols, A_vals = [], [], []
@@ -133,9 +133,12 @@ class PowCone(SetMembership):
 
         return prob.value
 
+    """
+    Returns the violation of the current values of this object 
+    """
     def violation(self, rough = False):
         if rough:
             return np.max([np.abs(self.z_low.value) - np.prod(np.power(self.w_low.value, self.alpha)), 0])
-
-        dist = PowCone.project(self.w, self.lamb)
-        return dist
+        else:
+            dist = PowCone.project(self.w, self.lamb)
+            return dist

--- a/sageopt/coniclifts/constraints/set_membership/pow_cone.py
+++ b/sageopt/coniclifts/constraints/set_membership/pow_cone.py
@@ -1,0 +1,141 @@
+import numpy as np
+from sageopt.coniclifts.constraints.set_membership.setmem import SetMembership
+from sageopt.coniclifts.base import Expression, ScalarVariable, Variable, ScalarExpression
+from sageopt.coniclifts.cones import Cone
+from sageopt.coniclifts.operators.norms import vector2norm
+from sageopt.coniclifts.problems.problem import Problem
+
+
+class PowCone(SetMembership):
+    _CONSTRAINT_ID_ = 0
+
+    """
+        Creates an instance of a Power Cone whose constraints are described in cone_standards.txt
+        
+         In this constructor, w is an (n+1)-vector and lamb is an (n+1) vector with exactly one negative 
+         component.  lamb in the input corresponds to alpha in the description of a power cone.
+         
+         The negative number in lamb corresponds to the index of w that is z in the description of a power cone.
+    """
+    def __init__(self, w, lamb):
+        self.id = PowCone._CONSTRAINT_ID_
+        PowCone._CONSTRAINT_ID_ += 1
+
+        # Finds indices of all positive elements of lambs (alpha)
+        pos_idxs = lamb > 0
+
+        #Error if lamb and w are not same size
+        if not w.size == lamb.size:
+            raise RuntimeError('Incompatible dimensions for w (' + str(w.size) + ') and alpha (' + str(lamb.size) + ')')
+
+        # Error if alpha has no negative number
+        if np.sum(pos_idxs) == np.size(lamb):
+            raise ValueError('No negative number in lamb array')
+
+        if np.sum(lamb[pos_idxs]) == lamb[lamb < 0]:
+            raise ValueError('lamb does not have sum of 0')
+        # Get positive values and normalize
+        alpha_low = lamb[pos_idxs]/np.abs(lamb[lamb < 0])
+
+
+        # Negative number corresponds to z in power cone and rest of numpy array is w
+        w_low = w[pos_idxs]
+        z_low = w[lamb < 0]
+
+        if not isinstance(w_low, Expression):
+            w_low = Expression(w_low)
+        if not isinstance(z_low, Expression):
+            z_low = Expression(z_low)
+
+        self.w = w
+        self.lamb = lamb
+        self.w_low = w_low
+        self.z_low = z_low
+        self.alpha = alpha_low
+        pass
+
+    """
+        Returns a list of all the variables asssociated with this power cone
+    """
+    def variables(self):
+
+        var_ids = set()
+        var_list = []
+
+        # Grab non duplicate elements from w
+        for se in self.w_low.ravel():
+            for sv in se.scalar_variables():
+                if id(sv.parent) not in var_ids:
+                    var_ids.add(id(sv.parent))
+                    var_list.append(sv.parent)
+
+        # Iterate through z and find new variables
+        for sv in self.z_low.scalar_variables():
+            if id(sv.parent) not in var_ids:
+                var_ids.add(id(sv.parent))
+                var_list.append(sv.parent)
+
+        return var_list
+
+    """
+    
+    """
+    def conic_form(self):
+        A_rows, A_cols, A_vals = [], [], []
+        K = [Cone('pow', self.w.size, annotations=self.alpha)]
+        b = np.zeros(shape=(self.w.size,))
+
+        # Loop through w and add every variable
+        for i, se in enumerate(self.w_low.flat):
+            if len(se.atoms_to_coeffs) == 0:
+                b[i] = se.offset
+                A_rows.append(i)
+                A_cols.append(ScalarVariable.curr_variable_count() - 1)
+                A_vals.append(0)  # make sure scipy infers correct dimensions later on.
+            else:
+                b[i] = se.offset
+                A_rows += [i] * len(se.atoms_to_coeffs)
+                col_idx_to_coeff = [(a.id, c) for a, c in se.atoms_to_coeffs.items()]
+                A_cols += [atom_id for (atom_id, _) in col_idx_to_coeff]
+                A_vals += [c for (_, c) in col_idx_to_coeff]
+
+        # Make final row of matrix the information about z
+        i = self.w_low.size
+        if len(self.z_low.atoms_to_coeffs) == 0:
+            b[i] = self.z_low.offset
+            A_rows.append(i)
+            A_cols.append(ScalarVariable.curr_variable_count() - 1)
+            A_vals.append(0)  # make sure scipy infers correct dimensions later on.
+        else:
+            b[i] = self.z_low.offset
+            A_rows += [i] * len(self.z_low.atoms_to_coeffs)
+            col_idx_to_coeff = [(a.id, c) for a, c in self.z_low.atoms_to_coeffs.items()]
+            A_cols += [atom_id for (atom_id, _) in col_idx_to_coeff]
+            A_vals += [c for (_, c) in col_idx_to_coeff]
+
+        return [(A_vals, np.array(A_rows), A_cols, b, K)]
+
+    @staticmethod
+    def project(item, alpha):
+        from sageopt.coniclifts import MIN as CL_MIN
+
+        item = Expression(item).ravel()
+        w = Variable(shape=(item.size, ))
+        t = Variable(shape=(1, ))
+
+        cons = [
+            vector2norm(item-w) <= t,
+            PowCone(w, alpha)
+        ]
+
+        prob = Problem(CL_MIN, t, cons)
+        prob.solve(verbose=False)
+
+        return prob.value
+
+    def violation(self, rough = False):
+        if rough:
+            return np.max([np.abs(self.z_low.value) - np.prod(np.power(self.w_low.value, self.alpha)), 0])
+
+        dist = PowCone.project(self.w, self.lamb)
+        return dist

--- a/sageopt/coniclifts/standards/cone_standards.txt
+++ b/sageopt/coniclifts/standards/cone_standards.txt
@@ -2,6 +2,10 @@ coniclifts uses the same exponential cone format as ECOS.
     K_exp = { (x,y,z) : y >= z * exp(x / z), z >= 0 }
 The constraint that (u, v, w) \in K_exp_dual can be represented by (-w, v, -u) \in K_exp.
     (See Santiago Akle Serrano's thesis, Section 8.3, page 71.)
+The power cone constraint will be parameterized by an n-vector “alpha” that’s elementwise positive and sums to 1.
+Informally, the constraint requires that ...
+    { (w, z) : np.prod(np.power(w, alpha)) >= np.abs(z), w >= 0 }.
+	    … where “w” is an n-vector and “z” is a scalar.
 
 
 coniclifts uses the same second order cone format as ECOS and mosek.

--- a/sageopt/coniclifts/standards/cone_standards.txt
+++ b/sageopt/coniclifts/standards/cone_standards.txt
@@ -2,6 +2,7 @@ coniclifts uses the same exponential cone format as ECOS.
     K_exp = { (x,y,z) : y >= z * exp(x / z), z >= 0 }
 The constraint that (u, v, w) \in K_exp_dual can be represented by (-w, v, -u) \in K_exp.
     (See Santiago Akle Serrano's thesis, Section 8.3, page 71.)
+
 The power cone constraint will be parameterized by an n-vector “alpha” that’s elementwise positive and sums to 1.
 Informally, the constraint requires that ...
     { (w, z) : np.prod(np.power(w, alpha)) >= np.abs(z), w >= 0 }.

--- a/sageopt/tests/test_coniclifts/test_compilers.py
+++ b/sageopt/tests/test_coniclifts/test_compilers.py
@@ -127,7 +127,7 @@ class TestCompilers(unittest.TestCase):
         assert np.allclose(b[:-1], expected_b[:-1])
         assert K[0] == Cone('pow', n+1, annotations=actual_annotations)
 
-        # Last test reconstrcuted from matrix creation
+        # Last test reconstructed from matrix creation
         x = Variable(shape=(n+1,), name='x')
         M = np.random.rand(n+1, n+1)
         y = M @ x
@@ -136,7 +136,3 @@ class TestCompilers(unittest.TestCase):
         A = A.toarray()
         assert np.allclose(A, M)
         assert K[0] == Cone('pow', n+1, annotations=actual_annotations)
-
-
-
-

--- a/sageopt/tests/test_coniclifts/test_compilers.py
+++ b/sageopt/tests/test_coniclifts/test_compilers.py
@@ -19,7 +19,7 @@ from sageopt.coniclifts.operators import affine
 from sageopt.coniclifts.base import Variable
 from sageopt.coniclifts.compilers import compile_constrained_system
 from sageopt.coniclifts.cones import Cone
-
+from sageopt.coniclifts.constraints.set_membership.pow_cone import PowCone
 
 def var_maps_equal(vm1, vm2):
     if not len(vm1) == len(vm2):
@@ -81,4 +81,58 @@ class TestCompilers(unittest.TestCase):
         expect_rows_3to6 = np.diag([C[0, 0] ** 2, C[0, 0] * C[1, 1], C[1, 1] ** 2])
         assert np.allclose(expect_rows_3to6, A[3:, :])
         assert np.all(b == np.array([5, -1, -1, 2, 2, 2]))
+
+    def test_power_cone_system(self):
+        n = 4
+        rng = np.random.default_rng(12345)
+
+        # Create w and z in one array, where the last one will be z
+        wz = Variable(shape=(n+1, 1), name='wz')
+
+        # Make the last element negative to indicate that that element is z in the wz variable
+        lamb = rng.random((n+1, 1))
+        lamb[-1] = -1*np.sum(lamb[:-1])
+
+        # Create simple constraints
+        constraints1 = [PowCone(wz, lamb)]
+        A, b, K, _, _, _ = compile_constrained_system(constraints1)
+        A = A.toarray()
+        assert np.allclose(A, np.identity(n+1))
+        assert np.allclose(b, np.zeros((n+1, 1)))
+        assert K[0] == Cone('pow', n+1, annotations='alpha')
+
+        # Increment z
+        wz[-1] += 1
+        constraints2 = [PowCone(wz, lamb)]
+        A, b, K, _, _, _ = compile_constrained_system(constraints2)
+        A = A.toarray()
+        assert np.allclose(A, np.identity(n + 1))
+        expected_b = np.zeros((n + 1, 1))
+        expected_b[-1] = 1
+        assert np.allclose(b, expected_b)
+        assert K[0] == Cone('pow', n + 1, annotations='alpha')
+
+        #Increment w
+        r = rng.random((n, 1))
+        wz[:-1] += r
+        constraints3 = [PowCone(wz, lamb)]
+        A, b, K, _, _, _ = compile_constrained_system(constraints3)
+        A = A.toarray()
+        assert np.allclose(A, np.identity(n + 1))
+        expected_b = r
+        assert np.allclose(b[:-1], expected_b)
+        assert K[0] == Cone('pow', n + 1, annotations='alpha')
+
+
+        x = Variable(shape=(n+1, 1), name='x')
+        M = np.random.rand((n+1, n+1))
+        y = M @ x
+        constraints4 = PowCone(y, lamb)
+        A, b, K, _, _, _ = compile_constrained_system(constraints4)
+        A = A.toarray()
+        assert np.allclose(A, M)
+        assert K[0] == Cone('pow', n + 1, annotations='alpha')
+
+
+
 

--- a/sageopt/tests/test_coniclifts/test_constraints.py
+++ b/sageopt/tests/test_coniclifts/test_constraints.py
@@ -24,6 +24,7 @@ from sageopt.coniclifts.constraints.set_membership import product_cone, psd_cone
 from sageopt.coniclifts.problems.problem import Problem
 from sageopt.coniclifts import MIN as CL_MIN
 from sageopt.symbolic.signomials import SigDomain
+from sageopt.coniclifts.constraints.set_membership.pow_cone import PowCone
 
 
 class TestConstraints(unittest.TestCase):
@@ -248,5 +249,31 @@ class TestConstraints(unittest.TestCase):
         val = prob.value
         assert val < 1e-7
 
+    def test_power_cone(self):
+        n = 4
+        rng = np.random.default_rng(12345)
 
+        # Create w and z in one array, where the last one will be z
+        wz = Variable(shape=(n + 1, 1), name='wz')
+
+        # Make the last element negative to indicate that that element is z in the wz variable
+        lamb = rng.random((n, 1))
+
+        # Check if wrong sizes that error is raised
+        self.assertRaises(RuntimeError, PowCone(wz, lamb))
+
+        # Check if no negative number lamb, error is raised
+        lamb = rng.random((n+1, 1))
+        self.assertRaises(ValueError, PowCone(wz, lamb))
+
+        # Check if not sum to 0, error is raised
+        lamb[-1] = -5 * np.sum(lamb[:-1])
+        self.assertRaises(ValueError, PowCone(wz, lamb))
+
+        lamb[-1] = -1 * np.sum(lamb[:-1])
+
+        pow_cone_constraint = PowCone(wz, lamb)
+
+        #Check if violation is correct
+        v1 = pow_cone_constraint.violation(rough=True)
 

--- a/sageopt/tests/test_coniclifts/test_constraints.py
+++ b/sageopt/tests/test_coniclifts/test_constraints.py
@@ -261,7 +261,7 @@ class TestConstraints(unittest.TestCase):
         lamb = rng.random((n,))
 
         # Check if wrong sizes that error is raised
-        self.assertRaises(RuntimeError, PowCone, wz, lamb)
+        self.assertRaises(ValueError, PowCone, wz, lamb)
 
         # Check if no negative number lamb, error is raised
         lamb = rng.random((n+1,))
@@ -280,7 +280,7 @@ class TestConstraints(unittest.TestCase):
         v1 = pow_cone_constraint.violation(rough=True)
         assert v1 < 1e-15
 
-        #Check if violation is correct for point inside of power cone
+        # Check if violation is correct for point inside of power cone
         wz.value = np.array([2, 1, 1, 1, 1])
 
         pow_cone_constraint = PowCone(wz, lamb)
@@ -288,7 +288,7 @@ class TestConstraints(unittest.TestCase):
         assert np.allclose(v1, 0)
 
 
-        #Check if violation is correct for point inside of power cone
+        # Check if violation is correct for point inside of power cone
         wz.value = np.array([1, 1, 1, 1, 2])
 
         pow_cone_constraint = PowCone(wz, lamb)


### PR DESCRIPTION
Added in a Power Cone constraint in powcones.py which follows the Constraint interface. 

The power cone constraint will be parameterized by an n-vector “alpha” that’s elementwise positive and sums to 1.
Informally, the constraint requires that ...
    { (w, z) : np.prod(np.power(w, alpha)) >= np.abs(z), w >= 0 }.
	    … where “w” is an n-vector and “z” is a scalar.

Test on the constraints and the compiled constrained system were also created and tested.