### PR TITLE
Multiplying coniclifts Variable objects and symbolic Signomial or Polynomial objects

### DIFF
--- a/sageopt/coniclifts/base.py
+++ b/sageopt/coniclifts/base.py
@@ -19,7 +19,8 @@ from collections import defaultdict
 from sageopt.coniclifts.constraints.elementwise import ElementwiseConstraint
 from sageopt.coniclifts.constraints.set_membership.psd_cone import PSD
 from sageopt.coniclifts.utilities import array_index_iterator, __REAL_TYPES__
-
+from sageopt.symbolic.polynomials import Polynomial
+from sageopt.symbolic.signomials import Signomial
 
 class ScalarAtom(object):
 
@@ -278,7 +279,7 @@ class ScalarExpression(object):
         return f
 
     def __mul__(self, other):
-        if isinstance(other, __REAL_TYPES__):
+        if isinstance(other, __REAL_TYPES__) or isinstance(other, Polynomial) or isinstance(other, Signomial):
             if other == 0:
                 return ScalarExpression(defaultdict(int), 0, verify=False, copy=False)
             f = ScalarExpression(self.atoms_to_coeffs, self.offset, verify=False)

--- a/sageopt/coniclifts/base.py
+++ b/sageopt/coniclifts/base.py
@@ -19,8 +19,6 @@ from collections import defaultdict
 from sageopt.coniclifts.constraints.elementwise import ElementwiseConstraint
 from sageopt.coniclifts.constraints.set_membership.psd_cone import PSD
 from sageopt.coniclifts.utilities import array_index_iterator, __REAL_TYPES__
-from sageopt.symbolic.polynomials import Polynomial
-from sageopt.symbolic.signomials import Signomial
 
 class ScalarAtom(object):
 
@@ -279,7 +277,7 @@ class ScalarExpression(object):
         return f
 
     def __mul__(self, other):
-        if isinstance(other, __REAL_TYPES__) or isinstance(other, Polynomial) or isinstance(other, Signomial):
+        if isinstance(other, __REAL_TYPES__) or 'Signomial' in str(type(other)) or 'Polynomial' in str(type(other)):
             if other == 0:
                 return ScalarExpression(defaultdict(int), 0, verify=False, copy=False)
             f = ScalarExpression(self.atoms_to_coeffs, self.offset, verify=False)

--- a/sageopt/tests/test_symbolic/test_signomials.py
+++ b/sageopt/tests/test_symbolic/test_signomials.py
@@ -148,6 +148,9 @@ class TestSignomials(unittest.TestCase):
         s = s0 * q0
         s = s.without_zeros()
         assert s.alpha_c == {(0,): 0}
+        z = cl.Variable()
+        a = z * s0
+        assert True
 
     def test_signomial_evaluation(self):
         s = Signomial.from_dict({(1,): 1})


### PR DESCRIPTION
Fixed GitHub issue #2 about left-multiplication by a coniclifts Expression. Coniclifts.base has been updated to check if one of the arguments to `__mul__` is a Signomial or Polynomial. If so, it falls back on the correct implementation of `__mul__`.
